### PR TITLE
Refactor testGetByPrefix test case to improve readability

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -206,14 +206,8 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithTableArbitraryPropPrefix() {
     //Arrangement
-    TestConfiguration tc = new TestConfiguration();
-
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
-
+    TestConfiguration tc = testGetByPrefixSetUpConfig();
+    //Expected Value
     Map<String,String> expected1 = new HashMap<>();
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
@@ -229,13 +223,7 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithTableIteratorScanPrefix() {
     //Arrangement
-    TestConfiguration tc = new TestConfiguration();
-
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
+    TestConfiguration tc = testGetByPrefixSetUpConfig();
 
     Map<String,String> expected2 = new HashMap<>();
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
@@ -252,13 +240,8 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixVFSContextClasspathProp() {
     //Arrangement
-    TestConfiguration tc = new TestConfiguration();
+    TestConfiguration tc = testGetByPrefixSetUpConfig();
 
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
     //Action
     Map<String,String> pm3 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
     //Assert
@@ -269,13 +252,7 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixGetOnePrefixNotRegenerateOther() {
     //Arrangement
-    TestConfiguration tc = new TestConfiguration();
-
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
+    TestConfiguration tc = testGetByPrefixSetUpConfig();
 
     Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     Map<String,String> pm2 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
@@ -297,23 +274,15 @@ public class AccumuloConfigurationTest {
   public void testGetByPrefixWithOneTimeRegeneratedTableIteratorScanPrefix() {
     //Arrangement
     //Init
-    TestConfiguration tc = new TestConfiguration();
-
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
-
+    TestConfiguration tc = testGetByPrefixSetUpConfig();
     Map<String,String> pm2 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
-
+    //Regenerate(check if the regeneration change other prefix)
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+    //Expected Value
     Map<String,String> expected2 = new HashMap<>();
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
-    //Regenerate
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
-
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
 
@@ -329,23 +298,15 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithOneTimeRegeneratedTableArbitraryPropPrefix(){
     //Arrangement
-    TestConfiguration tc = new TestConfiguration();
-
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
-
+    TestConfiguration tc = testGetByPrefixSetUpConfig();
     Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
-
+    //Regenerate
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+    //Expected Value
     Map<String,String> expected1 = new HashMap<>();
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    //check if the regeneration change other prefix
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
 
     //Action
     Map<String,String> pmC = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
@@ -358,15 +319,7 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithOneTimeRegeneratedVFSContextClasspathProp() {
     //Arrangement
-    //Init
-    TestConfiguration tc = new TestConfiguration();
-
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
-
+    TestConfiguration tc = testGetByPrefixSetUpConfig();
     Map<String,String> pm3 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
     //Regenerate
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
@@ -378,39 +331,29 @@ public class AccumuloConfigurationTest {
     //Assert
     assertSame(pmE, tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY));
     assertNotSame(pm3, pmE);
-    assertEquals(ImmutableMap.of(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123",
+    assertEquals(Map.of(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123",
             "hdfs://ib/p1"), pmE);
   }
 
   @Test
   public void testGetByPrefixWithTwiceRegeneratedTableIteratorScanPrefix() {
     //Arrangement
-    //init
-    TestConfiguration tc = new TestConfiguration();
-
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
-
+    TestConfiguration tc = testGetByPrefixSetUpConfig();
+    //Regenerate Once
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+    Map<String,String> pmA = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
+    //Regenerate Twice
+    tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
+    //Expected Value
     Map<String,String> expected2 = new HashMap<>();
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
-    //Regenerate
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
-
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
 
-    Map<String,String> pmA = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
-    //Regenerate
-    tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
-
     //Action
     Map<String,String> pmG = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
-
     //Assert
     assertNotSame(pmA, pmG);
     assertSame(pmG, tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX));
@@ -420,26 +363,17 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithTwiceRegeneratedTableArbitraryPropPrefix() {
     //Arrangement
-    //init
-    TestConfiguration tc = new TestConfiguration();
-
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
-
-    Map<String,String> expected1 = new HashMap<>();
-    expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
+    TestConfiguration tc = testGetByPrefixSetUpConfig();
     //Regenerate Once
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
-
     Map<String,String> pmC = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     //Regenerate Twice
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
+    //Expected Value
+    Map<String,String> expected1 = new HashMap<>();
+    expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
+    expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
 
     //Action
     Map<String,String> pmI = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
@@ -453,22 +387,12 @@ public class AccumuloConfigurationTest {
   public void testGetByPrefixGetOnePrefixNotRegenerateOtherAfterRegenerate(){
     //Arrangement
     //init
-    TestConfiguration tc = new TestConfiguration();
-
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
-
+    TestConfiguration tc = testGetByPrefixSetUpConfig();
     //Regenerate Once
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
-
-    Map<String,String> pmC = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     //Regenerate Twice
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
-
     Map<String,String> pmE = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
     Map<String,String> pmG = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
 
@@ -561,5 +485,18 @@ public class AccumuloConfigurationTest {
     ScanExecutorConfig sec8 =
         tc.getScanExecutors().stream().filter(c -> c.name.equals("hulksmash")).findFirst().get();
     assertEquals(44, sec8.maxThreads);
+  }
+  
+  public TestConfiguration testGetByPrefixSetUpConfig() {
+    // Universal Arrangement for GetByPrefix test cases
+    TestConfiguration tc = new TestConfiguration();
+
+    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
+    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
+
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
+    
+    return tc;
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -205,6 +205,7 @@ public class AccumuloConfigurationTest {
 
   @Test
   public void testGetByPrefixWithTableArbitraryPropPrefix() {
+    //Arrangement
     TestConfiguration tc = new TestConfiguration();
 
     tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
@@ -213,12 +214,14 @@ public class AccumuloConfigurationTest {
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
 
-    Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
-
     Map<String,String> expected1 = new HashMap<>();
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
 
+    //Action
+    Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+
+    //Assert
     assertSame(pm1, tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX));
     assertEquals(expected1, pm1);
   }
@@ -234,12 +237,12 @@ public class AccumuloConfigurationTest {
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
 
-    //Action
-    Map<String,String> pm2 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
-
     Map<String,String> expected2 = new HashMap<>();
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
+
+    //Action
+    Map<String,String> pm2 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
 
     // Assert
     assertSame(pm2, tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX));
@@ -293,6 +296,7 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithOneTimeRegeneratedTableIteratorScanPrefix() {
     //Arrangement
+    //Init
     TestConfiguration tc = new TestConfiguration();
 
     tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
@@ -324,6 +328,7 @@ public class AccumuloConfigurationTest {
 
   @Test
   public void testGetByPrefixWithOneTimeRegeneratedTableArbitraryPropPrefix(){
+    //Arrangement
     TestConfiguration tc = new TestConfiguration();
 
     tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
@@ -342,7 +347,9 @@ public class AccumuloConfigurationTest {
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
 
+    //Action
     Map<String,String> pmC = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+    //Assert
     assertNotSame(pm1, pmC);//not same instance
     assertSame(pmC, tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX));
     assertEquals(expected1, pmC);//same value
@@ -351,6 +358,7 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithOneTimeRegeneratedVFSContextClasspathProp() {
     //Arrangement
+    //Init
     TestConfiguration tc = new TestConfiguration();
 
     tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
@@ -360,11 +368,11 @@ public class AccumuloConfigurationTest {
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
 
     Map<String,String> pm3 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
-
     //Regenerate
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
+
     //Action
     Map<String,String> pmE = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
     //Assert

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -203,10 +203,29 @@ public class AccumuloConfigurationTest {
     assertThrows(UnsupportedOperationException.class, () -> pm1.put("k9", "v3"));
   }
 
+  public TestConfiguration setUpTestConfigForGetByPrefix() {
+    // Universal Arrangement for GetByPrefix test cases
+    TestConfiguration tc = new TestConfiguration();
+
+    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
+    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
+
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
+
+    return tc;
+  }
+
+  public TestConfiguration reSetTestConfigForGetByPrefix(TestConfiguration tc) {
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+    return tc;
+  }
+
   @Test
   public void testGetByPrefixWithTableArbitraryPropPrefix() {
     //Arrangement
-    TestConfiguration tc = testGetByPrefixSetUpConfig();
+    TestConfiguration tc = setUpTestConfigForGetByPrefix();
     //Expected Value
     Map<String,String> expected1 = new HashMap<>();
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
@@ -223,8 +242,8 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithTableIteratorScanPrefix() {
     //Arrangement
-    TestConfiguration tc = testGetByPrefixSetUpConfig();
-
+    TestConfiguration tc = setUpTestConfigForGetByPrefix();
+    //Expected Value
     Map<String,String> expected2 = new HashMap<>();
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
@@ -240,10 +259,11 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixVFSContextClasspathProp() {
     //Arrangement
-    TestConfiguration tc = testGetByPrefixSetUpConfig();
+    TestConfiguration tc = setUpTestConfigForGetByPrefix();
 
     //Action
     Map<String,String> pm3 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
+
     //Assert
     assertSame(pm3, tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY));
     assertEquals(0, pm3.size());
@@ -252,31 +272,31 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixGetOnePrefixNotRegenerateOther() {
     //Arrangement
-    TestConfiguration tc = testGetByPrefixSetUpConfig();
-
+    TestConfiguration tc = setUpTestConfigForGetByPrefix();
+    //Expected Value
     Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     Map<String,String> pm2 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
     Map<String,String> pm3 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
 
-    //Action & Assert
+    //Action
     //ensure getting one prefix does not cause others to unnecessarily regenerate
     Map<String,String> pm4 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
-    assertSame(pm1, pm4);
-
     Map<String,String> pm5 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
-    assertSame(pm2, pm5);
-
     Map<String,String> pm6 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
+
+    //Assert
+    assertSame(pm1, pm4);
+    assertSame(pm2, pm5);
     assertSame(pm3, pm6);
   }
 
   @Test
   public void testGetByPrefixWithOneTimeRegeneratedTableIteratorScanPrefix() {
     //Arrangement
-    TestConfiguration tc = testGetByPrefixSetUpConfig();
+    TestConfiguration tc = setUpTestConfigForGetByPrefix();
     Map<String,String> pm2 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
     //Regenerate(check if the regeneration change other prefix)
-    tc = reSetupTableIterScanPrefix(tc);
+    tc = reSetTestConfigForGetByPrefix(tc);
     //Expected Value
     Map<String,String> expected2 = new HashMap<>();
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
@@ -296,10 +316,10 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithOneTimeRegeneratedTableArbitraryPropPrefix(){
     //Arrangement
-    TestConfiguration tc = testGetByPrefixSetUpConfig();
+    TestConfiguration tc = setUpTestConfigForGetByPrefix();
     Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     //Regenerate
-    tc = reSetupTableIterScanPrefix(tc);
+    tc = reSetTestConfigForGetByPrefix(tc);
     //Expected Value
     Map<String,String> expected1 = new HashMap<>();
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
@@ -307,6 +327,7 @@ public class AccumuloConfigurationTest {
 
     //Action
     Map<String,String> pmC = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+
     //Assert
     assertNotSame(pm1, pmC);//not same instance
     assertSame(pmC, tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX));
@@ -316,15 +337,16 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithTwiceRegeneratedVFSContextClasspathProp() {
     //Arrangement
-    TestConfiguration tc = testGetByPrefixSetUpConfig();
+    TestConfiguration tc = setUpTestConfigForGetByPrefix();
     Map<String,String> pm3 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
-    //Regenerate Once
-    tc = reSetupTableIterScanPrefix(tc);
-    //Regenerate Twice
+    //Regenerate First Time
+    tc = reSetTestConfigForGetByPrefix(tc);
+    //Regenerate Second Time
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
 
     //Action
     Map<String,String> pmE = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
+
     //Assert
     assertSame(pmE, tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY));
     assertNotSame(pm3, pmE);
@@ -335,11 +357,11 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithTwiceRegeneratedTableIteratorScanPrefix() {
     //Arrangement
-    TestConfiguration tc = testGetByPrefixSetUpConfig();
-    //Regenerate Once
-    tc = reSetupTableIterScanPrefix(tc);
+    TestConfiguration tc = setUpTestConfigForGetByPrefix();
+    //Regenerate First Time
+    tc = reSetTestConfigForGetByPrefix(tc);
     Map<String,String> pmA = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
-    //Regenerate Twice
+    //Regenerate Second Time
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
     //Expected Value
     Map<String,String> expected2 = new HashMap<>();
@@ -350,6 +372,7 @@ public class AccumuloConfigurationTest {
 
     //Action
     Map<String,String> pmG = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
+
     //Assert
     assertNotSame(pmA, pmG);
     assertSame(pmG, tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX));
@@ -359,11 +382,11 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithTwiceRegeneratedTableArbitraryPropPrefix() {
     //Arrangement
-    TestConfiguration tc = testGetByPrefixSetUpConfig();
-    //Regenerate Once
-    tc = reSetupTableIterScanPrefix(tc);
+    TestConfiguration tc = setUpTestConfigForGetByPrefix();
+    //Regenerate First Time
+    tc = reSetTestConfigForGetByPrefix(tc);
     Map<String,String> pmC = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
-    //Regenerate Twice
+    //Regenerate Second Time
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
     //Expected Value
     Map<String,String> expected1 = new HashMap<>();
@@ -372,6 +395,7 @@ public class AccumuloConfigurationTest {
 
     //Action
     Map<String,String> pmI = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+
     //Assert
     assertNotSame(pmC, pmI);
     assertSame(pmI, tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX));
@@ -381,21 +405,21 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixGetOnePrefixNotRegenerateOtherAfterRegenerate(){
     //Arrangement
-    //init
-    TestConfiguration tc = testGetByPrefixSetUpConfig();
-    //Regenerate Once
-    tc = reSetupTableIterScanPrefix(tc);
-    //Regenerate Twice
+    TestConfiguration tc = setUpTestConfigForGetByPrefix();
+    //Regenerate First Time
+    tc = reSetTestConfigForGetByPrefix(tc);
+    //Regenerate Second Time
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
     Map<String,String> pmE = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
     Map<String,String> pmG = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
 
-    //Action & Assert
+    //Action
     //ensure getting one prefix does not cause others to unnecessarily regenerate
     Map<String,String> pmK = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
-    assertSame(pmE, pmK);
-
     Map<String,String> pmL = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
+
+    //Assert
+    assertSame(pmE, pmK);
     assertSame(pmG, pmL);
   }
 
@@ -479,24 +503,5 @@ public class AccumuloConfigurationTest {
     ScanExecutorConfig sec8 =
         tc.getScanExecutors().stream().filter(c -> c.name.equals("hulksmash")).findFirst().get();
     assertEquals(44, sec8.maxThreads);
-  }
-  
-  public TestConfiguration testGetByPrefixSetUpConfig() {
-    // Universal Arrangement for GetByPrefix test cases
-    TestConfiguration tc = new TestConfiguration();
-
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
-    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
-
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
-    
-    return tc;
-  }
-
-  public TestConfiguration reSetupTableIterScanPrefix(TestConfiguration tc) {
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
-    return tc;
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -224,31 +224,31 @@ public class AccumuloConfigurationTest {
 
   @Test
   public void testGetByPrefixWithTableArbitraryPropPrefix() {
-    //Arrangement
+    // Arrangement
     TestConfiguration tc = setUpTestConfigForGetByPrefix();
-    //Expected Value
+    // Expected Value
     Map<String,String> expected1 = new HashMap<>();
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
 
-    //Action
+    // Action
     Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
 
-    //Assert
+    // Assert
     assertSame(pm1, tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX));
     assertEquals(expected1, pm1);
   }
 
   @Test
   public void testGetByPrefixWithTableIteratorScanPrefix() {
-    //Arrangement
+    // Arrangement
     TestConfiguration tc = setUpTestConfigForGetByPrefix();
-    //Expected Value
+    // Expected Value
     Map<String,String> expected2 = new HashMap<>();
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
 
-    //Action
+    // Action
     Map<String,String> pm2 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
 
     // Assert
@@ -258,33 +258,33 @@ public class AccumuloConfigurationTest {
 
   @Test
   public void testGetByPrefixVFSContextClasspathProp() {
-    //Arrangement
+    // Arrangement
     TestConfiguration tc = setUpTestConfigForGetByPrefix();
 
-    //Action
+    // Action
     Map<String,String> pm3 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
 
-    //Assert
+    // Assert
     assertSame(pm3, tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY));
     assertEquals(0, pm3.size());
   }
 
   @Test
   public void testGetByPrefixGetOnePrefixNotRegenerateOther() {
-    //Arrangement
+    // Arrangement
     TestConfiguration tc = setUpTestConfigForGetByPrefix();
-    //Expected Value
+    // Expected Value
     Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     Map<String,String> pm2 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
     Map<String,String> pm3 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
 
-    //Action
-    //ensure getting one prefix does not cause others to unnecessarily regenerate
+    // Action
+    // ensure getting one prefix does not cause others to unnecessarily regenerate
     Map<String,String> pm4 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     Map<String,String> pm5 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
     Map<String,String> pm6 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
 
-    //Assert
+    // Assert
     assertSame(pm1, pm4);
     assertSame(pm2, pm5);
     assertSame(pm3, pm6);
@@ -292,88 +292,88 @@ public class AccumuloConfigurationTest {
 
   @Test
   public void testGetByPrefixWithOneTimeRegeneratedTableIteratorScanPrefix() {
-    //Arrangement
+    // Arrangement
     TestConfiguration tc = setUpTestConfigForGetByPrefix();
     Map<String,String> pm2 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
-    //Regenerate(check if the regeneration change other prefix)
+    // Regenerate(check if the regeneration change other prefix)
     tc = reSetTestConfigForGetByPrefix(tc);
-    //Expected Value
+    // Expected Value
     Map<String,String> expected2 = new HashMap<>();
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
 
-    //Action
+    // Action
     Map<String,String> pmA = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
 
-    //Assert
+    // Assert
     assertNotSame(pm2, pmA);
     assertSame(pmA, tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX));
     assertEquals(expected2, pmA);
   }
 
   @Test
-  public void testGetByPrefixWithOneTimeRegeneratedTableArbitraryPropPrefix(){
-    //Arrangement
+  public void testGetByPrefixWithOneTimeRegeneratedTableArbitraryPropPrefix() {
+    // Arrangement
     TestConfiguration tc = setUpTestConfigForGetByPrefix();
     Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
-    //Regenerate
+    // Regenerate
     tc = reSetTestConfigForGetByPrefix(tc);
-    //Expected Value
+    // Expected Value
     Map<String,String> expected1 = new HashMap<>();
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
 
-    //Action
+    // Action
     Map<String,String> pmC = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
 
-    //Assert
-    assertNotSame(pm1, pmC);//not same instance
+    // Assert
+    assertNotSame(pm1, pmC);// not same instance
     assertSame(pmC, tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX));
-    assertEquals(expected1, pmC);//same value
+    assertEquals(expected1, pmC);// same value
   }
 
   @Test
   public void testGetByPrefixWithTwiceRegeneratedVFSContextClasspathProp() {
-    //Arrangement
+    // Arrangement
     TestConfiguration tc = setUpTestConfigForGetByPrefix();
     Map<String,String> pm3 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
-    //Regenerate First Time
+    // Regenerate First Time
     tc = reSetTestConfigForGetByPrefix(tc);
-    //Regenerate Second Time
+    // Regenerate Second Time
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
 
-    //Action
+    // Action
     Map<String,String> pmE = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
 
-    //Assert
+    // Assert
     assertSame(pmE, tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY));
     assertNotSame(pm3, pmE);
-    assertEquals(Map.of(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123",
-            "hdfs://ib/p1"), pmE);
+    assertEquals(
+        Map.of(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1"), pmE);
   }
 
   @Test
   public void testGetByPrefixWithTwiceRegeneratedTableIteratorScanPrefix() {
-    //Arrangement
+    // Arrangement
     TestConfiguration tc = setUpTestConfigForGetByPrefix();
-    //Regenerate First Time
+    // Regenerate First Time
     tc = reSetTestConfigForGetByPrefix(tc);
     Map<String,String> pmA = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
-    //Regenerate Second Time
+    // Regenerate Second Time
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
-    //Expected Value
+    // Expected Value
     Map<String,String> expected2 = new HashMap<>();
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
 
-    //Action
+    // Action
     Map<String,String> pmG = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
 
-    //Assert
+    // Assert
     assertNotSame(pmA, pmG);
     assertSame(pmG, tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX));
     assertEquals(expected2, pmG);
@@ -381,48 +381,47 @@ public class AccumuloConfigurationTest {
 
   @Test
   public void testGetByPrefixWithTwiceRegeneratedTableArbitraryPropPrefix() {
-    //Arrangement
+    // Arrangement
     TestConfiguration tc = setUpTestConfigForGetByPrefix();
-    //Regenerate First Time
+    // Regenerate First Time
     tc = reSetTestConfigForGetByPrefix(tc);
     Map<String,String> pmC = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
-    //Regenerate Second Time
+    // Regenerate Second Time
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
-    //Expected Value
+    // Expected Value
     Map<String,String> expected1 = new HashMap<>();
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
 
-    //Action
+    // Action
     Map<String,String> pmI = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
 
-    //Assert
+    // Assert
     assertNotSame(pmC, pmI);
     assertSame(pmI, tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX));
     assertEquals(expected1, pmI);
   }
 
   @Test
-  public void testGetByPrefixGetOnePrefixNotRegenerateOtherAfterRegenerate(){
-    //Arrangement
+  public void testGetByPrefixGetOnePrefixNotRegenerateOtherAfterRegenerate() {
+    // Arrangement
     TestConfiguration tc = setUpTestConfigForGetByPrefix();
-    //Regenerate First Time
+    // Regenerate First Time
     tc = reSetTestConfigForGetByPrefix(tc);
-    //Regenerate Second Time
+    // Regenerate Second Time
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
     Map<String,String> pmE = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
     Map<String,String> pmG = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
 
-    //Action
-    //ensure getting one prefix does not cause others to unnecessarily regenerate
+    // Action
+    // ensure getting one prefix does not cause others to unnecessarily regenerate
     Map<String,String> pmK = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
     Map<String,String> pmL = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
 
-    //Assert
+    // Assert
     assertSame(pmE, pmK);
     assertSame(pmG, pmL);
   }
-
 
   @Test
   public void testScanExecutors() {

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -273,12 +273,10 @@ public class AccumuloConfigurationTest {
   @Test
   public void testGetByPrefixWithOneTimeRegeneratedTableIteratorScanPrefix() {
     //Arrangement
-    //Init
     TestConfiguration tc = testGetByPrefixSetUpConfig();
     Map<String,String> pm2 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
     //Regenerate(check if the regeneration change other prefix)
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+    tc = reSetupTableIterScanPrefix(tc);
     //Expected Value
     Map<String,String> expected2 = new HashMap<>();
     expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
@@ -301,8 +299,7 @@ public class AccumuloConfigurationTest {
     TestConfiguration tc = testGetByPrefixSetUpConfig();
     Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     //Regenerate
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+    tc = reSetupTableIterScanPrefix(tc);
     //Expected Value
     Map<String,String> expected1 = new HashMap<>();
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
@@ -317,13 +314,13 @@ public class AccumuloConfigurationTest {
   }
 
   @Test
-  public void testGetByPrefixWithOneTimeRegeneratedVFSContextClasspathProp() {
+  public void testGetByPrefixWithTwiceRegeneratedVFSContextClasspathProp() {
     //Arrangement
     TestConfiguration tc = testGetByPrefixSetUpConfig();
     Map<String,String> pm3 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
-    //Regenerate
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+    //Regenerate Once
+    tc = reSetupTableIterScanPrefix(tc);
+    //Regenerate Twice
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
 
     //Action
@@ -340,8 +337,7 @@ public class AccumuloConfigurationTest {
     //Arrangement
     TestConfiguration tc = testGetByPrefixSetUpConfig();
     //Regenerate Once
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+    tc = reSetupTableIterScanPrefix(tc);
     Map<String,String> pmA = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
     //Regenerate Twice
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
@@ -365,8 +361,7 @@ public class AccumuloConfigurationTest {
     //Arrangement
     TestConfiguration tc = testGetByPrefixSetUpConfig();
     //Regenerate Once
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+    tc = reSetupTableIterScanPrefix(tc);
     Map<String,String> pmC = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     //Regenerate Twice
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
@@ -389,8 +384,7 @@ public class AccumuloConfigurationTest {
     //init
     TestConfiguration tc = testGetByPrefixSetUpConfig();
     //Regenerate Once
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
-    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+    tc = reSetupTableIterScanPrefix(tc);
     //Regenerate Twice
     tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
     Map<String,String> pmE = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
@@ -497,6 +491,12 @@ public class AccumuloConfigurationTest {
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
     tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
     
+    return tc;
+  }
+
+  public TestConfiguration reSetupTableIterScanPrefix(TestConfiguration tc) {
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
     return tc;
   }
 }


### PR DESCRIPTION
## Description 
This pull request refactors the test case [testGetByPrefix](https://github.com/Codegass/accumulo/tree/main/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L206) in test class AccumuloConfigurationTest. Currently, this test case combines 10 different test scenarios for the getAllPropertiesWithPrefix(). The refactoring breaks this test case down into 10 separate test cases, each of which focuses on one scenario. This will make the test cases smaller and simpler---thus easier to understand and maintain. This should also make debugging easier since each test case is more focused.

Note that this refactor keeps the test logic related to `Property.VFS_CONTEXT_CLASSPATH_PROPERTY`, which will be [deprecated since accumulo 2.1.0.](https://github.com/Codegass/accumulo/blob/63b36c380de8d272ddef2ee2725f5e2deac024f2/core/src/main/java/org/apache/accumulo/core/conf/Property.java#L1177) 

## Motivation

- Make test cases smaller, simpler, and easier to understand: The original test case is too long and complicated with combined test scenarios. By extracting the test targets to 10 separate unit test cases focusing on specific test scenarios. Each test case is kept small and simple, and given a meaningful name to show its purpose. And each test case now follows the clear A-arrange, A-action, and A-assert structure, which is easy for anyone to quickly pick up and change in the future.

- Debugging will be much less of a headache. With the original one big test case, if it fails, it is difficult to tell why it fails, due to the cluttered structure. Now, separating into 10 test cases, each test case fails for only one scenario. This makes bugs more difficult to hide and debugging easier.

## Key Changes in this PR

- Replace the [testGetByPrefix](https://github.com/Codegass/accumulo/tree/main/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L206)  test case with 10 unit test, each unit test case is named based on the test target and its specific action or parameter in the testing:
  - [testGetByPrefixWithTableArbitraryPropPrefix](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L226-L240)
  - [testGetByPrefixWithTableIteratorScanPrefix](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L243-L257)
  - [testGetByPrefixVFSContextClasspathProp](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L260-L270)
  - [testGetByPrefixGetOnePrefixNotRegenerateOther](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L273-L291)

  - [testGetByPrefixWithOneTimeRegeneratedTableIteratorScanPrefix](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L294-L314)
  - [testGetByPrefixWithOneTimeRegeneratedTableArbitraryPropPrefix](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L317-L335)
  - [testGetByPrefixWithOneTimeRegeneratedVFSContextClasspathProp](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L338-L355)

  - [testGetByPrefixWithTwiceRegeneratedTableIteratorScanPrefix](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L358-L380)
  - [testGetByPrefixWithTwiceRegeneratedTableArbitraryPropPrefix](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L383-L403)
  - [testGetByPrefixGetOnePrefixNotRegenerateOtherAfterRegenerate](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L406-L424)

- The reused arrangement statements are extracted as [setUpTestConfigForGetByPrefix()](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L206-L217) and 
[reSetTestConfigForGetByPrefix()](https://github.com/Codegass/accumulo/tree/refactor-configurationTest/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java#L219-L223).