### PR TITLE
Replace the AssertEqual with AssumeThat to avoid unintended failure

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
@@ -18,8 +18,10 @@
  */
 package org.apache.accumulo.server;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -66,7 +68,7 @@ public class ServerContextTest {
   public void testSasl() throws Exception {
 
     testUser.doAs((PrivilegedExceptionAction<Void>) () -> {
-
+      //Arrangement Mock
       Properties clientProps = new Properties();
       clientProps.setProperty(ClientProperty.SASL_ENABLED.getKey(), "true");
       clientProps.setProperty(ClientProperty.SASL_KERBEROS_SERVER_PRIMARY.getKey(), "accumulo");
@@ -108,8 +110,12 @@ public class ServerContextTest {
 
       EasyMock.replay(factory, context, siteConfig);
 
-      assertEquals(ThriftServerType.SASL, context.getThriftServerType());
+      assumeThat(context.getThriftServerType(),is(ThriftServerType.SASL));
+
+      //Action
       SaslServerConnectionParams saslParams = context.getSaslParams();
+
+      //Assert
       assertEquals(new SaslServerConnectionParams(conf, token), saslParams);
       assertEquals(username, saslParams.getPrincipal());
 


### PR DESCRIPTION
## Description

This pull request refactors the test case [testSasl](https://github.com/Codegass/accumulo/tree/main/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java#L66) in test class ServerContextTest. Currently, the test case is asserting the test case arrangement, which will cause the unintended interruption in the test flow. Replace the assert with assume will void the issue.

### Motivation

- Make the test case assertion results focus on the test target, not the arrangement of the test case.
- Take advantage in JUnit assume functionality. The original test case uses the assertEqual to assert an arrangement, which will raise unintended interruption. By replacing it with the assumeThat, it will keep the CI process running and skip the test if the arrangement is unsatisfied.

### Key Changes in this PR

- Replace the [assertEqual](https://github.com/Codegass/accumulo/blob/b63e51de09db8518302f88705d9b1eb7c503a6e6/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java#L111) function with [assumeThat](https://github.com/Codegass/accumulo/blob/28bf1d1c0d1e8c9faff602ca8b8f15c6fab78ef6/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java#L113) function, so when the condition failed, the test case will skipped in the CI/CD.
