### PR TITLE
Refactor testHashMethod test case to improve readability

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.util;
 
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assume.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -38,8 +40,8 @@ public class PairTest {
     Pair<Integer,String> pair1 = new Pair<>(25, "twenty-five");
     Pair<Integer,String> pair2 = new Pair<>(25, "twenty-five");
 
-    assertNotSame(pair1, pair2);
-    assertEquals(pair1.hashCode(), pair2.hashCode());
+    assumeThat(pair1, sameInstance(pair2)); //make sure the arrangement is correct
+    assertEquals(pair1.hashCode(), pair2.hashCode());//assert
   }
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
@@ -31,18 +31,37 @@ import org.junit.jupiter.api.Test;
 public class PairTest {
 
   /**
-   * Test method for {@link org.apache.accumulo.core.util.Pair#hashCode()}.
+   * Test method for {@link org.apache.accumulo.core.util.Pair#hashCode()} with same value input.
    */
   @Test
-  public void testHashMethod() {
+  public void testHashMethodSameValue() {
     Pair<Integer,String> pair1 = new Pair<>(25, "twenty-five");
     Pair<Integer,String> pair2 = new Pair<>(25, "twenty-five");
-    Pair<Integer,String> pair3 = new Pair<>(null, null);
-    Pair<Integer,String> pair4 = new Pair<>(25, "twentyfive");
-    Pair<Integer,String> pair5 = new Pair<>(225, "twenty-five");
+
     assertNotSame(pair1, pair2);
     assertEquals(pair1.hashCode(), pair2.hashCode());
+  }
+
+  /**
+   * Test method for {@link org.apache.accumulo.core.util.Pair#hashCode()} with Null value input.
+   */
+  @Test
+  public void testHashMethodNullValue() {
+    Pair<Integer,String> pair2 = new Pair<>(25, "twenty-five");
+    Pair<Integer,String> pair3 = new Pair<>(null, null);
+
     assertNotSame(pair2, pair3);
+  }
+
+  /**
+   * Test method for {@link org.apache.accumulo.core.util.Pair#hashCode()} with different value input.
+   */
+  @Test
+  public void testHashMethodDiffValue() {
+    Pair<Integer,String> pair1 = new Pair<>(25, "twenty-five");
+    Pair<Integer,String> pair4 = new Pair<>(25, "twentyfive");
+    Pair<Integer,String> pair5 = new Pair<>(225, "twenty-five");
+
     assertNotEquals(pair1.hashCode(), pair4.hashCode());
     assertNotEquals(pair1.hashCode(), pair5.hashCode());
   }

--- a/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.util;
 
 import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assume.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -36,11 +37,11 @@ public class PairTest {
    * Test method for {@link org.apache.accumulo.core.util.Pair#hashCode()} with same value input.
    */
   @Test
-  public void testHashMethodSameValue() {
+  public void testHashMethodSame() {
     Pair<Integer,String> pair1 = new Pair<>(25, "twenty-five");
     Pair<Integer,String> pair2 = new Pair<>(25, "twenty-five");
 
-    assumeThat(pair1, sameInstance(pair2)); //make sure the arrangement is correct
+    assumeThat(pair1, not(sameInstance(pair2))); //make sure the arrangement is correct
     assertEquals(pair1.hashCode(), pair2.hashCode());//assert
   }
 
@@ -48,7 +49,7 @@ public class PairTest {
    * Test method for {@link org.apache.accumulo.core.util.Pair#hashCode()} with Null value input.
    */
   @Test
-  public void testHashMethodNullValue() {
+  public void testHashMethodNull() {
     Pair<Integer,String> pair2 = new Pair<>(25, "twenty-five");
     Pair<Integer,String> pair3 = new Pair<>(null, null);
 
@@ -59,7 +60,7 @@ public class PairTest {
    * Test method for {@link org.apache.accumulo.core.util.Pair#hashCode()} with different value input.
    */
   @Test
-  public void testHashMethodDiffValue() {
+  public void testHashMethodDiff() {
     Pair<Integer,String> pair1 = new Pair<>(25, "twenty-five");
     Pair<Integer,String> pair4 = new Pair<>(25, "twentyfive");
     Pair<Integer,String> pair5 = new Pair<>(225, "twenty-five");

--- a/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
@@ -53,7 +53,7 @@ public class PairTest {
     Pair<Integer,String> pair2 = new Pair<>(25, "twenty-five");
     Pair<Integer,String> pair3 = new Pair<>(null, null);
 
-    assertNotSame(pair2, pair3);
+    assertNotEquals(pair2.hashCode(), pair3.hashCode());
   }
 
   /**


### PR DESCRIPTION
## Description

This pull request refactors the test case [testHashMethod](https://github.com/Codegass/accumulo/tree/main/core/src/test/java/org/apache/accumulo/core/util/PairTest.java#L36) in test class PairTest. Currently, this test case combines 3 different test scenarios for the hashcode(). The refactoring breaks this test case down into 3 separate test cases, each of which focuses on one scenario. This will make the test cases more straightforward to understand.

Also, one [assertSame](https://github.com/Codegass/accumulo/tree/main/core/src/test/java/org/apache/accumulo/core/util/PairTest.java#L41) method (which is asserting the test arrangement) is replaced with [assumeThat](https://github.com/Codegass/accumulo/tree/refactor-PairTest/core/src/test/java/org/apache/accumulo/core/util/PairTest.java#L43) method to avoid unintended interruption in the test process.

### Motivation

- Make test cases easer to understand for each scenarios: The original test case combined 3 test scenarios in one test. By extracting the test targets to 3 separate unit test cases focusing on specific test scenarios. Each test case is given a meaningful name to show its purpose. And each test case now follows the clear A-arrange, A-action, and A-assert structure, which is easy for anyone to quickly pick up and change in the future.

- Test report will be more focusing on the test target. In the original test case, the test use the assertNotSame to check the arrangements for the actual testing target hashCode(), if it fails,  the report will mark a failure for the test case. This will cost developer extra time to check the test case. Now, by replacing the assertNotSame with assumeThat, CI\CD will automatically skip the testHashMethodSame case if there is any dependency issue. This will reduce the confusion in the test report.

- Fix the unclear test case. The special case with null value for the pair instance is corrected with hashcode result assertion. 

### Key Changes in this PR

- Replace the [testHashMethod](https://github.com/Codegass/accumulo/tree/main/core/src/test/java/org/apache/accumulo/core/util/PairTest.java#L36) test case with 3 unit test, each unit test case is named based on the test target and its specific action or parameter in the testing:

  - [testHashMethodSame](https://github.com/Codegass/accumulo/tree/refactor-PairTest/core/src/test/java/org/apache/accumulo/core/util/PairTest.java#L39-L45)
  - [testHashMethodNull](https://github.com/Codegass/accumulo/tree/refactor-PairTest/core/src/test/java/org/apache/accumulo/core/util/PairTest.java#L51-L56)
  - [testHashMethodDiff](https://github.com/Codegass/accumulo/tree/refactor-PairTest/core/src/test/java/org/apache/accumulo/core/util/PairTest.java#L62-L69)

- Replace the [assertSame](https://github.com/Codegass/accumulo/tree/main/core/src/test/java/org/apache/accumulo/core/util/PairTest.java#L41) method (which is asserting the test arrangement) is replaced with [assumeThat](https://github.com/Codegass/accumulo/tree/refactor-PairTest/core/src/test/java/org/apache/accumulo/core/util/PairTest.java#L43) method in the [testHashMethodSameValue](https://github.com/Codegass/accumulo/tree/refactor-PairTest/core/src/test/java/org/apache/accumulo/core/util/PairTest.java#L39-L45) case.