### PR TITLE
Refactor testZookeeperPortSpecific test case to improve readability

### DIFF
--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
@@ -42,15 +42,17 @@ public class MiniAccumuloConfigImplTest {
       new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
 
   @Test
-  public void testZookeeperPort() {
-
-    // set specific zookeeper port
+  public void testZookeeperPortSpecific() {
     MiniAccumuloConfigImpl config = new MiniAccumuloConfigImpl(tempFolder.getRoot(), "password")
-        .setZooKeeperPort(5000).initialize();
-    assertEquals(5000, config.getZooKeeperPort());
+            .setZooKeeperPort(5000).initialize();
 
-    // generate zookeeper port
-    config = new MiniAccumuloConfigImpl(tempFolder.getRoot(), "password").initialize();
+    assertEquals(5000, config.getZooKeeperPort());
+  }
+
+  @Test
+  public void testZookeeperPortGenerate() {
+    MiniAccumuloConfigImpl config = new MiniAccumuloConfigImpl(tempFolder.getRoot(), "password").initialize();
+
     assertTrue(config.getZooKeeperPort() > 0);
   }
 


### PR DESCRIPTION
## Description

This pull request refactors the test case [testZookeeperPort](https://github.com/Codegass/accumulo/tree/main/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java#L45) in test class PairTest. Currently, this test case combines 2 different test scenarios for the Zookeeper port initialization. The refactoring breaks this test case down into 2 separate test cases, each of which focuses on one scenario. This will will help the test case keep consistent and easier to test more the potential issues in one CI\CD cycle.

### Motivation

- Make test cases follow the same structure and naming conventions: The testZooKeeperStartupTime test case is a unit test and only consider of one scenario in one case. Split the original testZookeeperPort case into two unit test with more specific test name will help the test case keep consistent and easier to test more the potential issues in one CI\CD cycle.

  - [testZookeeperPortSpecific](https://github.com/Codegass/accumulo/tree/refactor-ZookeeperPort/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java#L45-L50) ensures the MiniAccumuloConfigImpl sets zookeeper's port explicitly from setZooKeeperPort().

  - [testZookeeperPortGenerate](https://github.com/Codegass/accumulo/tree/refactor-ZookeeperPort/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java#L53-L57) ensures that MiniAccumuloConfigImpl calls [getRandomFreePort()](https://github.com/Codegass/accumulo/blob/b63e51de09db8518302f88705d9b1eb7c503a6e6/server/base/src/main/java/org/apache/accumulo/server/util/PortUtils.java#L30) to automatically generate a random port for ZooKeeper when the port number is not explicitly set through setZooKeeperPort().

### Key Changes in this PR

- Replace the [testZookeeperPort](https://github.com/Codegass/accumulo/tree/main/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java#L45) test case with 2 unit test, each unit test case is named based on the test target and its specific action or parameter in the testing:

  - [testZookeeperPortSpecific](https://github.com/Codegass/accumulo/tree/refactor-ZookeeperPort/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java#L45-L50)
  - [testZookeeperPortGenerate](https://github.com/Codegass/accumulo/tree/refactor-ZookeeperPort/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java#L53-L57)
