### PR TITLE
Split the unnamed test in LargestFirstMemoryManagerTest into 8 test cases

### DIFF
--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java
@@ -119,7 +119,7 @@ public class LargestFirstMemoryManagerTest {
   }
 
   @Test
-  public void testOnefinishedOneProcessingOneFilledUp() {
+  public void testOneFinishedOneProcessingOneFilledUp() {
     // one finished, one in progress, one filled up
     tabletsToMinorCompact = mgr.tabletsToMinorCompact(tablets(t(k("a"), ZERO, HALF_GIG, 0),
             t(k("b"), ZERO, HALF_GIG + ONE_MEG, 0), t(k("c"), ZERO, HALF_GIG + (2 * ONE_MEG), 0),


### PR DESCRIPTION
## Description
This pull request refactors the unnamed test case [test()](https://github.com/Codegass/accumulo/tree/main/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java#66) in test class LargestFirstMemoryManagerTest. 

Currently, this test case combines 8 different test scenarios for the tabletsToMinorCompact(). The refactoring breaks this test case down into 8 separate test cases, each of which focuses on one scenario. This will make the test cases smaller and simpler---thus easier to understand and maintain. This should also make debugging easier since each test case is more focused.

### Motivation 

- Make test cases smaller, simpler, and easier to understand: The original test case is too long and unnamed with combined test scenarios. By extracting the test targets to 8 separate test cases focusing on specific test scenarios. Each test case's structure is easier to understand, and given a meaningful name to show its purpose.

- Debugging will be much less of a headache. With the original one big test case, if it fails, it is difficult to tell why it fails, due to the cluttered structure. Now, separating into 8 test cases, each test case fails for only one scenario. This makes bugs more difficult to hide and debugging easier.

### Key Changes in this PR
- Replace the [test](https://github.com/Codegass/accumulo/tree/refactor-largeFirstMemoryManagerTest/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java#66) test case with 8 test cases, each test case is named based on the test target and its specific action or parameter in the testing:
  - [testDoNothing](https://github.com/Codegass/accumulo/tree/refactor-largeFirstMemoryManagerTest/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java#70)
  - [testOneBigTabletWithOneIdle](https://github.com/Codegass/accumulo/tree/refactor-largeFirstMemoryManagerTest/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java#78)
  - [testOneIdleTablet](https://github.com/Codegass/accumulo/tree/refactor-largeFirstMemoryManagerTest/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java#87)
  - [testOneIdleOnBig](https://github.com/Codegass/accumulo/tree/refactor-largeFirstMemoryManagerTest/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java#97)
  - [testLotsTablet](https://github.com/Codegass/accumulo/tree/refactor-largeFirstMemoryManagerTest/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java#106)
  - [testOneFinishedOneProcessingOneFilledUp](https://github.com/Codegass/accumulo/tree/refactor-largeFirstMemoryManagerTest/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java#122)
  - [testMemoryTooManyCandidates](https://github.com/Codegass/accumulo/tree/refactor-largeFirstMemoryManagerTest/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java#L134-L170)
  - [testCompactLargeIsBusy](https://github.com/Codegass/accumulo/tree/refactor-largeFirstMemoryManagerTest/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java#L174-L205)
- The universal arrangement for these cases are extracted to the field of the class -- [Extracted Variables](https://github.com/Codegass/accumulo/tree/refactor-largeFirstMemoryManagerTest/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java#L65-L66).