### PR TITLE
Refactor base relative time test to improve readability

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java
@@ -20,8 +20,6 @@ package org.apache.accumulo.server.util.time;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeThat;
-import static org.hamcrest.CoreMatchers.equalTo;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -55,7 +53,6 @@ public class BaseRelativeTimeTest {
     pastAdvice.value -= 10000;
 
     brt = new BaseRelativeTime(local);
-    assumeThat(brt.currentTime(), equalTo(local.value));
   }
 
   @Test
@@ -103,7 +100,7 @@ public class BaseRelativeTimeTest {
     brt.updateTime(pastAdvice.value);
     long once = brt.currentTime();
     //Assert
-    assertTrue(once <= local.value);
+    assertTrue(once < local.value);
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java
@@ -20,10 +20,18 @@ package org.apache.accumulo.server.util.time;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
+import static org.hamcrest.CoreMatchers.equalTo;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class BaseRelativeTimeTest {
+
+  private BogusTime futureAdvice;
+  private BogusTime pastAdvice;
+  private BogusTime local;
+  private BaseRelativeTime brt;
 
   static class BogusTime implements ProvidesTime {
     public long value = 0;
@@ -32,6 +40,22 @@ public class BaseRelativeTimeTest {
     public long currentTime() {
       return value;
     }
+  }
+
+  @Before
+  public void setup(){
+    //Arrangement
+    futureAdvice = new BogusTime();
+    pastAdvice = new BogusTime();
+    local = new BogusTime();
+    local.value = futureAdvice.value = pastAdvice.value = System.currentTimeMillis();
+    // Ten seconds into the future
+    futureAdvice.value += 10000;
+    // Ten seconds into the past
+    pastAdvice.value -= 10000;
+
+    brt = new BaseRelativeTime(local);
+    assumeThat(brt.currentTime(), equalTo(local.value));
   }
 
   @Test
@@ -47,46 +71,49 @@ public class BaseRelativeTimeTest {
   }
 
   @Test
-  public void testFutureTime() {
-    BogusTime advice = new BogusTime();
-    BogusTime local = new BogusTime();
-    local.value = advice.value = System.currentTimeMillis();
-    // Ten seconds into the future
-    advice.value += 10000;
-
-    BaseRelativeTime brt = new BaseRelativeTime(local);
-    assertEquals(brt.currentTime(), local.value);
-    brt.updateTime(advice.value);
+  public void testFutureTimeOnce() {
+    //Action
+    brt.updateTime(futureAdvice.value);
     long once = brt.currentTime();
-    assertTrue(once < advice.value);
+    //Assert
+    assertTrue(once < futureAdvice.value);
     assertTrue(once > local.value);
-
-    for (int i = 0; i < 100; i++) {
-      brt.updateTime(advice.value);
-    }
-    long many = brt.currentTime();
-    assertTrue(many > once);
-    assertTrue("after much advice, relative time is still closer to local time",
-        (advice.value - many) < (once - local.value));
   }
 
   @Test
-  public void testPastTime() {
-    BogusTime advice = new BogusTime();
-    BogusTime local = new BogusTime();
-    local.value = advice.value = System.currentTimeMillis();
-    // Ten seconds into the past
-    advice.value -= 10000;
-
-    BaseRelativeTime brt = new BaseRelativeTime(local);
-    brt.updateTime(advice.value);
+  public void testFutureTimeManyTimes() {
+    //Action
+    brt.updateTime(futureAdvice.value);
     long once = brt.currentTime();
-    assertTrue(once < local.value);
-    brt.updateTime(advice.value);
-    long twice = brt.currentTime();
-    assertTrue("Time cannot go backwards", once <= twice);
-    brt.updateTime(advice.value - 10000);
-    assertTrue("Time cannot go backwards", once <= twice);
+
+    for (int i = 0; i < 100; i++) {
+      brt.updateTime(futureAdvice.value);
+    }
+    long many = brt.currentTime();
+
+    //Assert
+    assertTrue(many > once);
+    assertTrue("after much advice, relative time is still closer to local time",
+            (futureAdvice.value - many) < (once - local.value));
   }
 
+  @Test
+  public void testPastTimeOnce() {
+    //Action
+    brt.updateTime(pastAdvice.value);
+    long once = brt.currentTime();
+    //Assert
+    assertTrue(once <= local.value);
+  }
+
+  @Test
+  public void testPastTimeTwice() {
+    //Action
+    brt.updateTime(pastAdvice.value);
+    long once = brt.currentTime();
+    brt.updateTime(pastAdvice.value);
+    long twice = brt.currentTime();
+    //Assert
+    assertTrue("Time cannot go backwards", once <= twice);
+  }
 }


### PR DESCRIPTION
## Description
This pull request refactors the test case [testFutureTime](https://github.com/Codegass/accumulo/tree/main/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L50) and [testPastTime](https://github.com/Codegass/accumulo/tree/main/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L74) in test class BaseRelativeTimeTest.

These two test cases shares the similar arrangement process for the test, and both of them contain two different test scenarios for the updateTime() method. So I extract the universal arrangement to the setup function with @Before, and split the test cases to 4 unit tests. This should make debugging easier since each test case is more focused.

The [useless statement](https://github.com/Codegass/accumulo/blob/b63e51de09db8518302f88705d9b1eb7c503a6e6/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L88-L89) in testPastTime is removed, since it has no impact to the test.

### Motivation

* Make the test class more compact and simple to understand with good readability. The similar arrangement of the test cases are now extracted to the setup method, leaves the test case simple and easy to understand.
* Improve the maintainability. Separating the two cases into 4 test cases, each test case fails for only one scenario. This makes bugs more difficult to hide and debugging easier.

### Key Changes in this PR
- Replace the [testFutureTime](https://github.com/Codegass/accumulo/tree/main/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L50) test case with 2 test cases, each test case is named based on the test target and its specific action or parameter in the testing:
  - [testFutureTimeOnce](https://github.com/Codegass/accumulo/tree/refactor-baseRelativeTimeTestserver/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L71)
  - [testFutureTimeManyTimes](https://github.com/Codegass/accumulo/tree/refactor-baseRelativeTimeTestserver/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L81)
- Replace the [testPastTime](https://github.com/Codegass/accumulo/tree/main/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L74) test case with 2 test cases, each test case is named based on the test target and its specific action or parameter in the testing:
  - [testPastTimeOnce](https://github.com/Codegass/accumulo/tree/refactor-baseRelativeTimeTestserver/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L98)
  - [testPastTimeTwice](https://github.com/Codegass/accumulo/tree/refactor-baseRelativeTimeTestserver/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L107)
- Extract the universal arrangement for the test cases into the [setup](https://github.com/Codegass/accumulo/tree/refactor-baseRelativeTimeTestserver/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L44) function with @Before annotation.
- Remove the [useless Assertion](https://github.com/Codegass/accumulo/tree/main/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L58) in testFutureTime, which is asserting the arrangement, and also cause conflict when extracting to the setup function.
- Remove the [useless Assertion](https://github.com/Codegass/accumulo/blob/b63e51de09db8518302f88705d9b1eb7c503a6e6/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java#L88-L89) in testPastTime, which has no impact to the test assertion.
